### PR TITLE
Removed superfluous slashes from Star and WooCommerce fonts urls

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -104,23 +104,23 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 				'storefront-woocommerce-style',
 				'@font-face {
 				font-family: star;
-				src: url(' . $fonts_url . '/star.eot);
+				src: url(' . $fonts_url . 'star.eot);
 				src:
-					url(' . $fonts_url . '/star.eot?#iefix) format("embedded-opentype"),
-					url(' . $fonts_url . '/star.woff) format("woff"),
-					url(' . $fonts_url . '/star.ttf) format("truetype"),
-					url(' . $fonts_url . '/star.svg#star) format("svg");
+					url(' . $fonts_url . 'star.eot?#iefix) format("embedded-opentype"),
+					url(' . $fonts_url . 'star.woff) format("woff"),
+					url(' . $fonts_url . 'star.ttf) format("truetype"),
+					url(' . $fonts_url . 'star.svg#star) format("svg");
 				font-weight: 400;
 				font-style: normal;
 			}
 			@font-face {
 				font-family: WooCommerce;
-				src: url(' . $fonts_url . '/WooCommerce.eot);
+				src: url(' . $fonts_url . 'WooCommerce.eot);
 				src:
-					url(' . $fonts_url . '/WooCommerce.eot?#iefix) format("embedded-opentype"),
-					url(' . $fonts_url . '/WooCommerce.woff) format("woff"),
-					url(' . $fonts_url . '/WooCommerce.ttf) format("truetype"),
-					url(' . $fonts_url . '/WooCommerce.svg#WooCommerce) format("svg");
+					url(' . $fonts_url . 'WooCommerce.eot?#iefix) format("embedded-opentype"),
+					url(' . $fonts_url . 'WooCommerce.woff) format("woff"),
+					url(' . $fonts_url . 'WooCommerce.ttf) format("truetype"),
+					url(' . $fonts_url . 'WooCommerce.svg#WooCommerce) format("svg");
 				font-weight: 400;
 				font-style: normal;
 			}'


### PR DESCRIPTION
Since the $fonts_url already contains a trailing slash, I have removed the slashes from the @font-face declarations for the WooCommerce and Star fonts.

<!-- Reference any related issues or PRs here -->
Fixes #1742

<!-- Briefly describe the issue or problem that this PR solves. -->
Removes the duplicate slash in the fonts url

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
Fixes potential issues with rewrites and cache.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. View the source of your website, and find star.eot
2. Check if the url contains a duplicate slash
3. Check if all icons are displayed properly 
